### PR TITLE
fix issues uncovered after implementing DI

### DIFF
--- a/IpWebCam3.Tests/IpWebCam3.Tests.csproj
+++ b/IpWebCam3.Tests/IpWebCam3.Tests.csproj
@@ -61,6 +61,9 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />

--- a/IpWebCam3.Tests/Services/ImageServices/ImageFromCacheServiceTests.cs
+++ b/IpWebCam3.Tests/Services/ImageServices/ImageFromCacheServiceTests.cs
@@ -129,7 +129,7 @@ namespace IpWebCam3.Tests.Services.ImageServices
             int fpsTimeBetweenTwoFramesMilliSec = 1000 / cacheFps;
 
             // Act
-            int waitTimeMilliSec = cachingService.WaitBeforeGettingNextImage(userId: cacheReaderUserId, timeRequested: timeWhenCacheIsRead);
+            (int waitTimeMilliSec, string reason) = cachingService.WaitBeforeGettingNextImage(userId: cacheReaderUserId, timeRequested: timeWhenCacheIsRead);
 
             // Assert
             Assert.That(waitTimeMilliSec, Is.EqualTo(expectedWaitTimeMilliSec));

--- a/IpWebCam3.Tests/Services/ImageServices/ImageProviderServiceTests.cs
+++ b/IpWebCam3.Tests/Services/ImageServices/ImageProviderServiceTests.cs
@@ -1,5 +1,5 @@
-﻿using IpWebCam3.Helpers;
-using IpWebCam3.Helpers.ImageHelpers;
+﻿using IpWebCam3.Helpers.ImageHelpers;
+using IpWebCam3.Helpers.Logging;
 using IpWebCam3.Helpers.TimeHelpers;
 using IpWebCam3.Models;
 using IpWebCam3.Services.ImageServices;
@@ -51,9 +51,7 @@ namespace IpWebCam3.Tests.Services.ImageServices
                 dateTimeProvider: dateTimeService,
                 logger: _logger,
                 cacheUpdaterExpirationMilliSec: 1000,
-                imageErrorLogoUrl: "some_value",
-                cacheUpdaterInfo: null
-                )
+                cacheUpdaterInfo: null, imageErrorLogoUrl: "some_value")
             );
         }
 
@@ -68,9 +66,7 @@ namespace IpWebCam3.Tests.Services.ImageServices
                 dateTimeProvider: _dateTimeProvider,
                 logger: _logger,
                 cacheUpdaterExpirationMilliSec: expirationValueMilliSec,
-                imageErrorLogoUrl: "some_value",
-                cacheUpdaterInfo: null
-                )
+                cacheUpdaterInfo: null, imageErrorLogoUrl: "some_value")
             );
         }
 
@@ -129,9 +125,11 @@ namespace IpWebCam3.Tests.Services.ImageServices
             // Arrange
             const string userUtc = "some_UTC_value";
             _dateTimeProvider.DateTimeNow.Returns(new DateTime(2019, 05, 01, 15, 30, 30, 100));
-            _imageFromCacheService.WaitBeforeGettingNextImage(Arg.Any<int>(), Arg.Any<DateTime>()).Returns(0);
+            (int waitTimeMilliSec, string reason) valueTuple = (0, ""); 
+            _imageFromCacheService.WaitBeforeGettingNextImage(Arg.Any<int>(), Arg.Any<DateTime>()).Returns(valueTuple);
 
             _imageFromCacheService.GetNewImageAsByteArray(Arg.Any<int>(), Arg.Any<DateTime>()).Returns((byte[])null);
+
             _cacheUpdater.Update(userId: cacheUpdaterUserId, lastUpdate: DateTime.MinValue);
 
             var imageFromWebCam = new Bitmap(1, 1);
@@ -162,7 +160,8 @@ namespace IpWebCam3.Tests.Services.ImageServices
             // Arrange
             const string userUtc = "some_UTC_value";
             _dateTimeProvider.DateTimeNow.Returns(new DateTime(2019, 05, 01, 15, 30, 30, 100));
-            _imageFromCacheService.WaitBeforeGettingNextImage(Arg.Any<int>(), Arg.Any<DateTime>()).Returns(0);
+            (int waitTimeMilliSec, string reason) valueTuple = (0, "");
+            _imageFromCacheService.WaitBeforeGettingNextImage(Arg.Any<int>(), Arg.Any<DateTime>()).Returns(valueTuple);
 
             _imageFromCacheService.GetNewImageAsByteArray(Arg.Any<int>(), Arg.Any<DateTime>()).Returns((byte[])null);
             var currentImageArrayFromCache = new byte[20];
@@ -201,9 +200,7 @@ namespace IpWebCam3.Tests.Services.ImageServices
                 dateTimeProvider: _dateTimeProvider,
                 logger: _logger,
                 cacheUpdaterExpirationMilliSec: _cacheUpdaterExpirationMilliSec,
-                imageErrorLogoUrl: "some_value",
-                cacheUpdaterInfo: _cacheUpdater
-                );
+                cacheUpdaterInfo: _cacheUpdater, imageErrorLogoUrl: "some_value");
         }
 
         private DateTime RequestTime(int delayMilliSec)

--- a/IpWebCam3.Tests/packages.config
+++ b/IpWebCam3.Tests/packages.config
@@ -7,4 +7,5 @@
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net461" />
   <package id="NUnit" version="3.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/IpWebCam3.sln.DotSettings
+++ b/IpWebCam3.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ADDR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hscan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Milli/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ONVIF/@EntryIndexedValue">True</s:Boolean>

--- a/IpWebCam3/App_Start/UnityConfig.cs
+++ b/IpWebCam3/App_Start/UnityConfig.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Web.Http;
-using IpWebCam3.Helpers;
 using IpWebCam3.Helpers.Configuration;
+using IpWebCam3.Helpers.Logging;
 using IpWebCam3.Helpers.TimeHelpers;
 using IpWebCam3.Models;
 using IpWebCam3.Services.ImageServices;
+using System;
+using System.Web.Http;
 using Unity;
 using Unity.AspNet.WebApi;
 using Unity.Injection;
@@ -52,9 +52,9 @@ namespace IpWebCam3
             // container.RegisterType<IProductRepository, ProductRepository>();
 
             // Register interfaces
-            AppConfiguration _configuration = AppConfiguration.Instance;
+            AppConfiguration configuration = AppConfiguration.Instance;
             container.RegisterInstance(
-                                _configuration,
+                                configuration,
                                 new ContainerControlledLifetimeManager() //Singleton
                 );
 
@@ -88,7 +88,10 @@ namespace IpWebCam3
                 ));
 
             var cacheUpdater = new CacheUpdaterInfo();
-            container.RegisterInstance(cacheUpdater);
+            container.RegisterInstance(
+                                cacheUpdater,
+                                new ContainerControlledLifetimeManager() //Singleton
+                );
 
             container.RegisterType<IImageProviderService, ImageProviderService>(
                         new InjectionConstructor(
@@ -97,8 +100,8 @@ namespace IpWebCam3
                                 container.Resolve<IDateTimeProvider>(),
                                 container.Resolve<IMiniLogger>(),
                                 container.Resolve<AppConfiguration>().CacheUpdaterExpirationMilliSec,
-                                container.Resolve<AppConfiguration>().ErrorImageLogPath,
-                                container.Resolve<CacheUpdaterInfo>()
+                                container.Resolve<CacheUpdaterInfo>(),
+                                container.Resolve<AppConfiguration>().ErrorImageLogPath
                 ));
 
 

--- a/IpWebCam3/Controllers/ImageController.cs
+++ b/IpWebCam3/Controllers/ImageController.cs
@@ -2,13 +2,13 @@
 using IpWebCam3.Helpers.ImageHelpers;
 using IpWebCam3.Services.ImageServices;
 using System.Collections.Concurrent;
-using System.Drawing;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Web;
 using System.Web.Http;
 using IpWebCam3.Helpers.Configuration;
+using IpWebCam3.Helpers.Logging;
 using IpWebCam3.Helpers.TimeHelpers;
 
 namespace IpWebCam3.Controllers
@@ -19,19 +19,20 @@ namespace IpWebCam3.Controllers
 
         private readonly string _snapshotImagePath;
         private readonly IImageProviderService _imageProviderService;
-
+ 
         public ImageController(IImageProviderService imageProviderService,
-                                AppConfiguration configuration, 
-                                IDateTimeProvider dateTimeProvider, 
-                                IMiniLogger logger)
+                               AppConfiguration configuration, 
+                               IDateTimeProvider dateTimeProvider, 
+                               IMiniLogger logger)
             : base( configuration,  dateTimeProvider, logger)
         {
             _imageProviderService = imageProviderService;
             _snapshotImagePath = AppConfiguration.SnapShotImagePath;
-            AddConnectedUser();
+
+            RegisterConnectedUser();
         }
 
-        private void AddConnectedUser()
+        private void RegisterConnectedUser()
         {
             if (ConnectedUsers.ContainsKey(UserId))
                 return;
@@ -49,8 +50,7 @@ namespace IpWebCam3.Controllers
 
             if (imageByteArray == null) return null;
 
-            SaveImageSnapshot(imageByteArray);
-
+            ImageFileWriter.SaveImageSnapshot(imageByteArray, DateTimeProviderInstance, _snapshotImagePath, Logger, UserId, UserIp);
             HttpResponseMessage response = CreateImageResponseMessage(imageByteArray);
 
             return response;
@@ -67,34 +67,12 @@ namespace IpWebCam3.Controllers
             return response;
         }
 
-        private void SaveImageSnapshot(byte[] imageAsBytes)
-        {
-            if (!IsTimeToWriteAPicture())
-                return;
-
-            Image image = ImageHelper.ConvertByteArrayToImage(imageAsBytes);
-            ImageFileWriter.WriteImageToFile(image, DateTimeProvider.DateTimeNow, _snapshotImagePath, Logger);
-        }
-
-        // ToDo: read these values from config and move this method out of here
-        private bool IsTimeToWriteAPicture()
-        {
-            return
-                DateTimeProvider.DateTimeNow.Second >= 00 && // provide an interval of a few seconds to avoid
-                DateTimeProvider.DateTimeNow.Second <= 03 // missing time ending in '00' seconds
-            &&
-            (
-                DateTimeProvider.DateTimeNow.Minute == 00 ||
-                DateTimeProvider.DateTimeNow.Minute == 15 ||
-                DateTimeProvider.DateTimeNow.Minute == 30 ||
-                DateTimeProvider.DateTimeNow.Minute == 45);
-        }
-
+        
 
         private void LogNewUserHasConnected()
         {
             string currentBrowserInfo = HttpContextHelper.GetBrowserInfo(HttpContext.Current);
-            Logger?.LogUserIp(UserIp, UserId, currentBrowserInfo);
+            Logger?.LogUserIp(UserId, UserIp, currentBrowserInfo);
         }
     }
 }

--- a/IpWebCam3/Controllers/PtzController.cs
+++ b/IpWebCam3/Controllers/PtzController.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Web.Http;
 using IpWebCam3.Helpers;
 using IpWebCam3.Helpers.Configuration;
+using IpWebCam3.Helpers.Logging;
 using IpWebCam3.Helpers.TimeHelpers;
 using IpWebCam3.Services.PtzServices;
 
@@ -39,12 +40,12 @@ namespace IpWebCam3.Controllers
                                                             connectionInfo: AppConfiguration.CameraConnectionInfo);
             if (result.Error != null)
             {
-                Logger?.LogError(result.Message);
+                Logger?.LogError(result.Message, UserId, UserIp);
                 return new HttpResponseMessage(result.StatusCode);
             }
             else
             {
-                Logger?.LogUserPtz(result.Message);
+                Logger?.LogUserPtz(result.Message, UserId, UserIp);
                 return new HttpResponseMessage(HttpStatusCode.InternalServerError);
             }
         }

--- a/IpWebCam3/Helpers/Logging/LogExtensionMethods.cs
+++ b/IpWebCam3/Helpers/Logging/LogExtensionMethods.cs
@@ -1,0 +1,10 @@
+﻿namespace IpWebCam3.Helpers.Logging
+{
+    public static class LogExtensionMethods
+    {
+        public static string GetFormattedUserId(this int id)
+        {
+            return id.ToString().PadLeft(12, ' ');
+        }
+    }
+}

--- a/IpWebCam3/Helpers/Logging/MiniLogger.cs
+++ b/IpWebCam3/Helpers/Logging/MiniLogger.cs
@@ -2,18 +2,17 @@
 using System;
 using System.IO;
 
-namespace IpWebCam3.Helpers
+namespace IpWebCam3.Helpers.Logging
 {
     public interface IMiniLogger
     {
-        void SetUserInfo(string currentUserIp, int currentUserId);
-        void LogError(string errorMessage);
+        void LogError(string errorMessage, int userId, string userIp = null);
 
-        void LogUserIp(string userIp, int userId, string currentBrowserInfo) //(string text)
-            ;
+        void LogUserIp(int userId, string userIp, string currentBrowserInfo);
 
-        void LogUserPtz(string ptzMessage);
-        void LogCacheStat(string statMessage);
+        void LogUserPtz(string ptzMessage, int userId, string userIp);
+
+        void LogCacheStat(string cacheMessage, int userId);
     }
 
     /// <summary>
@@ -29,10 +28,6 @@ namespace IpWebCam3.Helpers
         private static string _logErrorsPath;
         private static string _logCacheStatsPath;
 
-        private string _currentUserIp;
-        private int _currentUserId;
-
-
         public MiniLogger(IDateTimeProvider dateTimeProvider,
                           string logUserIPsPath, string logUserPtzCmdPath,
                           string logErrorsPath, string logCacheStatsPath)
@@ -43,35 +38,32 @@ namespace IpWebCam3.Helpers
             _logErrorsPath = logErrorsPath;
             _logCacheStatsPath = logCacheStatsPath;
         }
+        
 
-        public void SetUserInfo(string currentUserIp, int currentUserId)
+        public void LogError(string errorMessage, int userId, string userIp = null)
         {
-            _currentUserIp = currentUserIp;
-            _currentUserId = currentUserId;
-        }
-
-        public void LogError(string errorMessage)
-        {
-            errorMessage = _currentUserIp + "," + _currentUserId + "," + errorMessage.Replace(",", "_");
+            errorMessage = userIp + "," + userId + "," + errorMessage.Replace(",", "_");
             WriteToLogFile(_logErrorsPath, errorMessage);
         }
 
-        public void LogUserIp(string userIp, int userId, string currentBrowserInfo) //(string text)
+        public void LogUserIp(int userId, string userIp, string currentBrowserInfo)
         {
             string logInfo = userIp + "," + userId + "," + currentBrowserInfo.Replace(",", "_");
             WriteToLogFile(_logUserIPsPath, logInfo);
         }
 
 
-        public void LogUserPtz(string ptzMessage)
+        public void LogUserPtz(string ptzMessage, int userId, string userIp)
         {
-            ptzMessage = _currentUserIp + "," + _currentUserId + "," + ptzMessage.Replace(",", "_");
+            ptzMessage = userIp + "," + userId + "," + ptzMessage.Replace(",", "_");
             WriteToLogFile(_logUserPtzCmdPath, ptzMessage);
         }
 
-        public void LogCacheStat(string statMessage)
+        public void LogCacheStat(string cacheMessage, int userId)
         {
-            WriteToLogFile(_logCacheStatsPath, statMessage.Replace(",", "_"));
+            cacheMessage = cacheMessage.Replace(",", "_");
+            cacheMessage = userId.GetFormattedUserId() + "," + cacheMessage;
+            WriteToLogFile(_logCacheStatsPath, cacheMessage);
         }
 
 
@@ -118,5 +110,6 @@ namespace IpWebCam3.Helpers
                     _dateTimeProvider.DateTimeNow.ToString("_yyyy-MM-dd") + ".txt");
             }
         }
+
     }
 }

--- a/IpWebCam3/IpWebCam3.csproj
+++ b/IpWebCam3/IpWebCam3.csproj
@@ -131,13 +131,14 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\Logging\LogExtensionMethods.cs" />
     <Compile Include="Services\ImageServices\CacheUpdateService.cs" />
     <Compile Include="Helpers\Configuration\ConfigExtensionMethods.cs" />
     <Compile Include="Helpers\HttpContextHelper.cs" />
     <Compile Include="Helpers\Configuration\AppConfiguration.cs" />
     <Compile Include="Helpers\ImageHelpers\ImageConverter.cs" />
     <Compile Include="Helpers\ImageHelpers\ImageFileWriter.cs" />
-    <Compile Include="Helpers\MiniLogger.cs" />
+    <Compile Include="Helpers\Logging\MiniLogger.cs" />
     <Compile Include="Helpers\Result.cs" />
     <Compile Include="Helpers\TimeHelpers\DateTimeFormatter.cs" />
     <Compile Include="Helpers\TimeHelpers\DateTimeProvider.cs" />

--- a/IpWebCam3/Models/ImageInfo.cs
+++ b/IpWebCam3/Models/ImageInfo.cs
@@ -3,7 +3,7 @@
 namespace IpWebCam3.Models
 {
     /// <summary>
-    /// Additional info for a cached image
+    /// image data + additional info useful for cache management
     /// </summary>
     public class ImageInfo
     {

--- a/IpWebCam3/Services/ImageServices/CacheUpdateService.cs
+++ b/IpWebCam3/Services/ImageServices/CacheUpdateService.cs
@@ -9,36 +9,36 @@ namespace IpWebCam3.Services.ImageServices
     /// </summary>
     public class CacheUpdateService
     {
-        private static readonly ImageInfo CachedImage = new ImageInfo();
+        private static readonly ImageInfo CachedImageInfo = new ImageInfo();
         private static readonly object LockCachedData = new object();
 
         public void UpdateImage(byte[] imgBytes, int userId, DateTime timeUpdated)
         {
             lock (LockCachedData)
             {
-                CachedImage.ImageAsByteArray = imgBytes;
-                CachedImage.UpdatedByUserId = userId;
-                CachedImage.LastUpdated = timeUpdated;
+                CachedImageInfo.ImageAsByteArray = imgBytes;
+                CachedImageInfo.UpdatedByUserId = userId;
+                CachedImageInfo.LastUpdated = timeUpdated;
             }
         }
 
-        public byte[] ImageAsByteArray => CachedImage.ImageAsByteArray;
+        public byte[] ImageAsByteArray => CachedImageInfo.ImageAsByteArray;
 
-        public int UserId => CachedImage.UpdatedByUserId;
+        public int UserId => CachedImageInfo.UpdatedByUserId;
 
-        public DateTime LastUpdate => CachedImage.LastUpdated;
+        public DateTime LastUpdate => CachedImageInfo.LastUpdated;
 
-        public bool HasData => !(CachedImage?.ImageAsByteArray == null || 
-                                 CachedImage?.UpdatedByUserId == 0 || 
-                                 CachedImage?.LastUpdated == DateTime.MinValue);
+        public bool HasData => !(CachedImageInfo?.ImageAsByteArray == null || 
+                                 CachedImageInfo?.UpdatedByUserId == 0 || 
+                                 CachedImageInfo?.LastUpdated == DateTime.MinValue);
 
         public void Clear()
         {
             lock (LockCachedData)
             {
-                CachedImage.ImageAsByteArray = null;
-                CachedImage.UpdatedByUserId = 0;
-                CachedImage.LastUpdated = DateTime.MinValue;
+                CachedImageInfo.ImageAsByteArray = null;
+                CachedImageInfo.UpdatedByUserId = 0;
+                CachedImageInfo.LastUpdated = DateTime.MinValue;
             }
         }
     }


### PR DESCRIPTION
After transition to DI, services needed to be updated:
- Before DI, services were created by the controllers for each Http Request, so they preserved the "state" of the request (userId and userIp).
- After DI, services became distinct reusable objects, so I had to find a way to store the actions of each individual user, such as last time it has read from cache.

In this scope, the  last time each user has accesses the cache is stored into as ConcurrentDictionary collection.  